### PR TITLE
Fix issue 113

### DIFF
--- a/src/extension/content.js
+++ b/src/extension/content.js
@@ -48,6 +48,8 @@
 
         // we could add a if case here to add tooltip disable pref.
         updateLinkTooltip();
+
+        registerEvents();
     }
 
     // Get settings from addon
@@ -68,7 +70,7 @@
                 $(fileLinkSelectors.join(', ')).disconnect();
                 $(document).disconnect();
                 // remove click handler
-                $(document).undelegate(fileLinkSelectors.join(', '), 'click');
+                unregisterEvents();
                 break;
             case 'init':
                 // console.log('init content script', request);
@@ -90,19 +92,6 @@
             default:
             }
         });
-    // self.port.on('init', function(addonOptions, constants) {
-    //     // console.log('init', addonOptions, constants);
-    //     appTextMessages = constants.MESSAGES.USERMESSAGES;
-
-    //     // load plugin options
-    //     options = addonOptions;
-
-    //     // console.log('test', appTextMessages);
-    //     $icon = $container.append($('<i/>').addClass('material-icons'));
-
-    //     // now everything is ready to load
-    //     activate();
-    // });
 
     // Update settings on change of pref.
     function updateIcons(data) {
@@ -121,7 +110,21 @@
     // self.port.on('prefChange:revealOpenOption', updateIcons);
 
     // Use delegate so the click event is also avaliable at newly added links
-    $(document).on('click', fileLinkSelectors.join(', '), function(e) {
+    function registerEvents() {
+        $(document).on('click', fileLinkSelectors.join(', '), openFileHandler);
+
+        // icon click handler
+        $(document).on('click',
+        '[class^=\'aliensun-link-icon\']',// folder or arrow
+        openFolderHandler);
+    }
+
+    function unregisterEvents() {
+        $(document).off('click', fileLinkSelectors.join(', '), openFileHandler);
+        $(document).off('click', '[class^=\'aliensun-link-icon\']', openFolderHandler);
+    }
+
+    function openFileHandler(e) {
         e.preventDefault(); // prevent default to avoid browser to launch smb://
         // console.log('clicked file link: ' +
         //   this.href, options.revealOpenOption);
@@ -139,7 +142,7 @@
         }).catch(function(error) {
             // console.log('error', error);
         });
-    });
+    }
 
     /*
     Event for icon to reveal the folder directly
@@ -172,11 +175,6 @@
             // console.log('error', err);
         });
     }
-
-    // icon click handler
-    $(document).on('click',
-    '[class^=\'aliensun-link-icon\']',// folder or arrow
-    openFolderHandler);
 
     // -------------------------------------------------------------------------
     // add link icons (if enabled)

--- a/test/webserver/index.htm
+++ b/test/webserver/index.htm
@@ -46,6 +46,7 @@ it does not if the page is served by a webserver; thats what the add-on is for).
     
 <p><a href="issue-iframe/index.html">Issue Iframe - re-loading issue (like at jsfiddle)</a></p>
 <p><a href="issue106/index.html">Issue 106 - address in link e.g. 192.168.2.x</a></p>
+<p><a href="issue113/index.html">Issue 113 - Multiple windows opened</a></p>
 
 
 </body>

--- a/test/webserver/issue113/index.html
+++ b/test/webserver/issue113/index.html
@@ -1,0 +1,18 @@
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=100%, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Issue 113 - Multiple windows opened </title>
+</head>
+<body>
+    <p>
+        First load: file links are correctly handled. <br/>
+        After click on normal link the file links opens multiple windows.
+    </p>
+    <ul>
+        <li><a href="https://www.google.com">Link to google (no file link)</a></li>
+        <li><a href="file://c:/tmp/existing_file.txt" target="_blank">existing_file.txt</a></li>
+    </ul>
+</body>
+</html>


### PR DESCRIPTION
This fixes issue #113.

It just adds an additional check (background/index.js line 36) if the tab that is reloading is the active tab to avoid the wrong removal of the current tab from `injectedTabs` Array. The wrong removal injected the content script multiple times.

The array keeps track of the tabs at which we injected the content script. With-out that array the content script would be injected multiple times.